### PR TITLE
Fixed issue with VS changes not being picked up by watch. Changed the…

### DIFF
--- a/Cake.Watch/FileWatch.cs
+++ b/Cake.Watch/FileWatch.cs
@@ -1,46 +1,63 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Cake.Watch {
-	public class FileWatch {
-		public void Watch(string pattern, Action<string> changedPath) {
-			var settings = new WatchSettings { Pattern = pattern, Path = "./", Recursive = true };
-			Watch(settings, changedPath);
-		}
+    public class FileWatch {
+        public void Watch(string pattern, Action<IEnumerable<string>> changedPath) {
+            var settings = new WatchSettings { Pattern = pattern, Path = "./", Recursive = true };
+            Watch(settings, changedPath);
+        }
 
-		public void Watch(WatchSettings settings, Action<string> changedPath) {
-			var watcher = new System.IO.FileSystemWatcher();
-			watcher.Path = settings.Path;
-			watcher.NotifyFilter =
-				       System.IO.NotifyFilters.Size; // | System.IO.NotifyFilters.LastAccess | System.IO.NotifyFilters.LastWrite;
-			watcher.Filter = settings.Pattern;
-			watcher.EnableRaisingEvents = true;
-			watcher.IncludeSubdirectories = settings.Recursive;
+        public void Watch(WatchSettings settings, Action<IEnumerable<string>> changedPath) {
+            var watcher = new FileSystemWatcher {
+                Path = settings.Path,
+                NotifyFilter = NotifyFilters.FileName | NotifyFilters.LastWrite | NotifyFilters.CreationTime,
+                Filter = settings.Pattern,
+                EnableRaisingEvents = true,
+                IncludeSubdirectories = settings.Recursive
+            };
 
-			var lastWatch = DateTime.MinValue;
+            var locker = new object();
+            var currentSource = new CancellationTokenSource();
+            var changedFiles = new List<string>();
+            Func<CancellationTokenSource, bool> isCanceled = c => c == null || c.IsCancellationRequested;
+            Action<FileSystemEventArgs> doWatch = (e) => {
+                if (!isCanceled(currentSource)) {
+                    lock (locker) {
+                        if (!isCanceled(currentSource)) {
+                            currentSource?.Cancel();
+                            currentSource = new CancellationTokenSource();
+                        }
 
-			Action<System.IO.FileSystemEventArgs> doWatch = (e) => {
-				var fullPath = e.FullPath;
-				var lastWriteTime = System.IO.File.GetLastWriteTime(fullPath);
-				if (lastWriteTime.Ticks != lastWatch.Ticks) {
-					changedPath(fullPath);
-				}
-				lastWatch = lastWriteTime;
-			};
+                        changedFiles.Add(e.FullPath);
+                    }
+                }
 
-			var locker = new Object();
+                // Forces multiple file changes to run the task only once when made in rapid succession.
+                // This prevents the create -> rename VS does from triggering 2 calls while still appearing to be instant.
+                Task.Delay(TimeSpan.FromSeconds(0.25), currentSource.Token)
+                    .ContinueWith(t => {
+                        List<string> localChanged;
+                        lock (locker) {
+                            localChanged = new List<string>(changedFiles.Distinct());
+                            changedFiles.Clear();
+                        }
 
-			watcher.Changed += (s, e) => {
-				lock (locker)
-					doWatch(e);
-			};
+                        changedPath(localChanged);
+                    },
+                    currentSource.Token);
+            };
 
-			watcher.Created += (s, e) => {
-				lock (locker)
-					doWatch(e);
-			};
+            watcher.Changed += (s, e) => doWatch(e);
+            watcher.Created += (s, e) => doWatch(e);
+            watcher.Renamed += (s, e) => doWatch(e);
 
-			while (System.Console.ReadLine() != "q") { }
-		}
-	}
+            while (Console.ReadLine() != "q") { }
+        }
+    }
 }
 

--- a/Cake.Watch/WatchAlias.cs
+++ b/Cake.Watch/WatchAlias.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Cake.Core;
 using Cake.Core.Annotations;
 
@@ -6,12 +7,12 @@ namespace Cake.Watch {
 	public static class WatchAlias {
 
 		[CakeMethodAlias]
-		public static void Watch(this ICakeContext context, string filePath, Action<string> fileChanged) {
+		public static void Watch(this ICakeContext context, string filePath, Action<IEnumerable<string>> fileChanged) {
 			new FileWatch().Watch(filePath, fileChanged);
 		}
 		
 		[CakeMethodAlias]
-		public static void Watch(this ICakeContext context, WatchSettings settings, Action<string> fileChanged) {
+		public static void Watch(this ICakeContext context, WatchSettings settings, Action<IEnumerable<string>> fileChanged) {
 			new FileWatch().Watch(settings, fileChanged);
 		}
 	}


### PR DESCRIPTION
### This is an interface change on the Watch callback. This will break existing clients.

- Changed the Watch method to support queuing multiple file changes because the way Visual Studio saves could spam the watch callback.
- Added the rename event handler to support Visual Studio changes.
- This could be made better by adding a Delay property to the settings with a default of 0.25 sec.

Sorry for the whole file change. I was getting really strange formatting after pushing to git and the only way to fix it was to fix tabs in VS.

### Tested On
Windows 10 using both VSCode and Visual Studio 2015
Cake v0.15.2
.NET 4.6.1 and Mono 4.4.1