### PR TITLE
Add projectUrl in nuspec

### DIFF
--- a/src/Cake.Watch/Cake.Watch.csproj
+++ b/src/Cake.Watch/Cake.Watch.csproj
@@ -5,6 +5,7 @@
         <TargetFramework>netstandard2.0</TargetFramework>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <PackageIconUrl>https://cdn.rawgit.com/cake-contrib/graphics/a5cf0f881c390650144b2243ae551d5b9f836196/png/cake-contrib-medium.png</PackageIconUrl>
+        <PackageProjectUrl>https://github.com/wk-j/cake-watch</PackageProjectUrl>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Cake.Core" Version="0.30.0" />


### PR DESCRIPTION
This value is used by Cake's automated audit tool to generate documentation about your addin.